### PR TITLE
Add a workflow in GitHub Actions Workflow to run RSpec

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+jobs:
+  ci:
+    runs-on: ${{ matrix.os }}
+    name: Ruby ${{ matrix.ruby }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+        ruby:
+          - "2.6"
+          - "2.7"
+          - "3.0"
+          - "3.1"
+          - "3.2"
+          - "head"
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - name: Run the default task
+        run: bundle exec rake

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
 
 require "bundler/gem_tasks"
-task default: %i[]
+require 'rspec/core/rake_task'
+
+RSpec::Core::RakeTask.new(:spec)
+task default: :spec


### PR DESCRIPTION
I think it would be nice if we could test on an ongoing basis in CI. WDYT?

This PR does the following:
- [Add a task to RakeTask to test RSpec](https://github.com/thehighhigh/natural_sort_jp/commit/fb705a1c6bfe513f2508ba5dbf6529cc443f117b)
- [Add a workflow in GitHub Actions Workflow to run RSpec](https://github.com/thehighhigh/natural_sort_jp/commit/ece306e70a1b093e4998538fc7a087a84a68cc98)