### PR TITLE
use scan method for improve performance

### DIFF
--- a/lib/natural_sort_jp.rb
+++ b/lib/natural_sort_jp.rb
@@ -15,8 +15,8 @@ module NaturalSortJp
   end
 
   def self.convert(title)
-    elements = title.to_s.gsub(/[0-9０-９]+/, ',\&,').split(',')
-    elements.map { |t| Element.new(t) }
+    elements = title.to_s.scan(/([^0-9０-９]*)([0-9０-９]*)/).flatten
+    elements.map { |t| Element.new(t) if t != '' }
   end
 
   def self.referenced_by_attribute(obj, attribute)


### PR DESCRIPTION
before
```
Finished in 0.03372 seconds (files took 0.15419 seconds to load)
33 examples, 0 failures
```


after
```
Finished in 0.0204 seconds (files took 0.08934 seconds to load)
33 examples, 0 failures
```